### PR TITLE
Tweak naming- 'successfulDecode' to 'conclusiveDecode'

### DIFF
--- a/core/src/main/scala/com/gu/play/secretrotation/SnapshotProvider.scala
+++ b/core/src/main/scala/com/gu/play/secretrotation/SnapshotProvider.scala
@@ -11,7 +11,16 @@ trait SecretsSnapshot {
 
   def description: String
 
-  def decode[T](decodingFunc: SecretConfiguration => T, successfulDecode: T => Boolean): Option[T]
+  /**
+    * @param decodingFunc a function that attempts to decode a value using the provided secret
+    * @param conclusiveDecode If true, no further attempts to decode with other secrets will be made,
+    *                      and the decoding result will be returned, wrapped in an Option.
+    *                      Note that a decode can be conclusive without the decoded value being *valid* -
+    *                      eg. the value may have been signed with a valid secret but expired due to it's
+    *                      own expiration constraints, or even maliciously signed with an unacceptable
+    *                      algorithm (eg a weak algorithm, even 'none' : https://tools.ietf.org/html/rfc7519#section-6.1 )
+    */
+  def decode[T](decodingFunc: SecretConfiguration => T, conclusiveDecode: T => Boolean): Option[T]
 }
 
 trait SnapshotProvider {


### PR DESCRIPTION
The `play-secret-rotation` library has a convenience `decode()` method, which tries the supplied decoding function with each accepted secret in turn (accepted secrets: the current 'active' secret, and the prior one, if we're still in the overlap period). The `successfulDecode` predicate determines whether or not we should stop searching - however it was badly named: a decode can be _conclusive_ without the decoded value being *valid* - eg. the value may have been signed with a valid secret but expired due to it's own expiration constraints, or even maliciously signed with an unacceptable algorithm (eg a weak algorithm, even 'none' : https://tools.ietf.org/html/rfc7519#section-6.1 )

So, this is just a small change to give the predicate a name to better indicate how it can be used: `conclusiveDecode` - this will be used in a forthcoming update to the `play-googleauth` library allowing it handle secret-rotation for the anti-forgery token-signing.
