### PR TITLE
Support multiple Play versions (ie v2.6 & v2.7)

### DIFF
--- a/aws-parameterstore/secret-supplier/SecretSupplier.scala
+++ b/aws-parameterstore/secret-supplier/SecretSupplier.scala
@@ -2,8 +2,6 @@ package com.gu.play.secretrotation.aws.parameterstore
 
 import com.gu.play.secretrotation.DualSecretTransition.{InitialSecret, TransitioningSecret}
 import com.gu.play.secretrotation.{CachingSnapshotProvider, SnapshotProvider, TransitionTiming}
-import play.api.Logger
-import play.api.http.SecretConfiguration
 
 /**
   * @param ssmClient use the implementation of this compiled against AWS SDK v1 or v2
@@ -22,18 +20,18 @@ class SecretSupplier(
     val latestVersion = latestValue.metadata.version
 
     val state = latestVersion match {
-      case InitialVersion => InitialSecret(SecretConfiguration(latestValue.value))
+      case InitialVersion => InitialSecret(latestValue.value)
       case _ =>
         val previousVersion = latestVersion - 1
         val previousValue = ssmClient.fetchValues(Seq(s"$parameterName:$previousVersion")).head
         TransitioningSecret(
-          oldSecret = SecretConfiguration(previousValue.value),
-          newSecret = SecretConfiguration(latestValue.value),
+          oldSecret = previousValue.value,
+          newSecret = latestValue.value,
           overlapInterval =
             transitionTiming.overlapIntervalForSecretPublishedAt(latestValue.metadata.lastModified)
         )
     }
-    Logger.info(s"Fetched Secret state: ${state.snapshot().description}")
+    logger.info(s"Fetched Secret state: ${state.snapshot().description}")
     state
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,9 @@ lazy val baseSettings = Seq(
 lazy val core =
   project.settings(baseSettings: _*).settings(
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play" % "2.6.17",
-      "org.threeten" % "threeten-extra" % "1.4",
+      "com.github.blemale" %% "scaffeine" % "2.6.0",
+      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
+      "org.threeten" % "threeten-extra" % "1.5.0",
       "org.scalatest" %% "scalatest" % "3.0.5" % "test"
     )
   )
@@ -44,9 +45,26 @@ lazy val `aws-parameterstore-lambda` = project.in(file("aws-parameterstore/lambd
 
 lazy val `secret-generator` = project.settings(baseSettings: _*)
 
+val exactPlayVersions = Map(
+  "26" -> "2.6.23",
+  "27" -> "2.7.3"
+)
+
+def playVersion(majorMinorVersion: String)= {
+  Project(s"play-v$majorMinorVersion", file(s"play/play-v$majorMinorVersion"))
+    .settings(baseSettings: _*)
+    .dependsOn(core)
+    .settings(libraryDependencies += "com.typesafe.play" %% "play" % exactPlayVersions(majorMinorVersion))
+}
+
+lazy val `play-v26` = playVersion("26")
+lazy val `play-v27` = playVersion("27")
+
 lazy val `play-secret-rotation-root` = (project in file("."))
   .aggregate(
     core,
+    `play-v26`,
+    `play-v27`,
     `aws-parameterstore-secret-supplier-base`,
     `aws-parameterstore-sdk-v1`,
     `aws-parameterstore-sdk-v2`,

--- a/play/play-v26/RotatingSecretComponents.scala
+++ b/play/play-v26/RotatingSecretComponents.scala
@@ -14,7 +14,7 @@ trait RotatingSecretComponents extends BuiltInComponentsFromContext {
   val secretStateSupplier: SnapshotProvider
 
   override def configuration: Configuration = {
-    val nonRotatingSecretOnlyUsedToSatisfyConfigChecks: String = secretStateSupplier.snapshot().secrets.active.secret
+    val nonRotatingSecretOnlyUsedToSatisfyConfigChecks = secretStateSupplier.snapshot().secrets.active
 
     super.configuration ++ Configuration("play.http.secret.key" -> nonRotatingSecretOnlyUsedToSatisfyConfigChecks)
   }
@@ -38,7 +38,7 @@ object RotatingSecretComponents {
 
     implicit val c: Clock = systemUTC()
 
-    private def jwtCodecFor(secret: SecretConfiguration) = DefaultJWTCookieDataCodec(secret, jwtConfiguration)
+    private def jwtCodecFor(secret: String) = DefaultJWTCookieDataCodec(SecretConfiguration(secret), jwtConfiguration)
 
     override def encode(data: Map[String, String]): String =
       jwtCodecFor(snapshotProvider.snapshot().secrets.active).encode(data)

--- a/play/play-v27/RotatingSecretComponents.scala
+++ b/play/play-v27/RotatingSecretComponents.scala
@@ -1,0 +1,1 @@
+../play-v26/RotatingSecretComponents.scala


### PR DESCRIPTION
After this change, in order to use `play-secret-rotation` in your project, you will need to specify it as **two** dependencies, not one. Eg in your `build.sbt`:

#### BEFORE

```
libraryDependencies +=
  "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "0.14"
```

#### AFTER

```
libraryDependencies ++= Seq(
  "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "0.15",
  "com.gu.play-secret-rotation" %% "play-v27" % "0.15"
)
```

...the first line says what supplier you want to use for secrets, the second version of Play you want to use.

### The matrix of versions for Play (2.6, 2.7) & AWS SDK (v1, v2)

Removing use of the `play.api.http.SecretConfiguration` class in the core `com.gu.play.secretrotation` package meant that a lot of the code could become agnostic as to Play-version - all the Play-related code could be pushed out to some new small artifacts:

* `com.gu.play-secret-rotation:play-v26`
* `com.gu.play-secret-rotation:play-v27`

...because those artifacts are the only place where Play-related code happens, it's now possible to use them in any combination with other `com.gu.play-secret-rotation` artifacts - ie you have freedom to choose whatever version of secret supplier you prefer, with whatever version of Play you prefer, eg these artifact combinations are fine:

* `play-v26` & `aws-parameterstore-sdk-v2`
* `play-v27` & `aws-parameterstore-sdk-v1`
