### PR TITLE
Add Scala 2.13 support everywhere we can (ie Play 2.7, but not Play 2.6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-   - 2.12.8
+   - 2.12.10
 
 jdk:
   - openjdk8

--- a/aws-parameterstore/secret-supplier/MinimalAwsSdkWrapper.scala
+++ b/aws-parameterstore/secret-supplier/MinimalAwsSdkWrapper.scala
@@ -10,5 +10,5 @@ case class ParameterValue(value: String, metadata: Metadata)
   * so that we can support both versions of the AWS SDK simultaneously.
   */
 trait MinimalAwsSdkWrapper {
-  def fetchValues(parameters: Seq[String]): Seq[ParameterValue]
+  def fetchValues(parameters: Seq[String]): Iterable[ParameterValue]
 }

--- a/aws-parameterstore/secret-supplier/aws-sdk-v1/AwsSdkV1.scala
+++ b/aws-parameterstore/secret-supplier/aws-sdk-v1/AwsSdkV1.scala
@@ -6,7 +6,7 @@ import com.amazonaws.services.simplesystemsmanagement.model.GetParametersRequest
 import scala.collection.JavaConverters._
 
 case class AwsSdkV1(ssmClient: AWSSimpleSystemsManagement) extends MinimalAwsSdkWrapper {
-  override def fetchValues(parameters: Seq[String]): Seq[ParameterValue] = ssmClient.getParameters(
+  override def fetchValues(parameters: Seq[String]): Iterable[ParameterValue] = ssmClient.getParameters(
     new GetParametersRequest()
       .withWithDecryption(true)
       .withNames(parameters.asJavaCollection)

--- a/aws-parameterstore/secret-supplier/aws-sdk-v2/AwsSdkV2.scala
+++ b/aws-parameterstore/secret-supplier/aws-sdk-v2/AwsSdkV2.scala
@@ -5,7 +5,7 @@ import software.amazon.awssdk.services.ssm.SsmClient
 import scala.collection.JavaConverters._
 
 case class AwsSdkV2(ssmClient: SsmClient) extends MinimalAwsSdkWrapper{
-  override def fetchValues(parameters: Seq[String]): Seq[ParameterValue] = ssmClient.getParameters(
+  override def fetchValues(parameters: Seq[String]): Iterable[ParameterValue] = ssmClient.getParameters(
     _.withDecryption(true).names(parameters.asJavaCollection)
   ).parameters.asScala.map(p => ParameterValue(p.value, Metadata(p.version, p.lastModifiedDate)))
 }

--- a/core/src/main/scala/com/gu/play/secretrotation/DualSecretTransition.scala
+++ b/core/src/main/scala/com/gu/play/secretrotation/DualSecretTransition.scala
@@ -22,7 +22,7 @@ object DualSecretTransition {
 
   object Phase {
 
-    class PhaseAge(val active: Age, val alsoAccepted: Traversable[Age] = None) extends PhaseAges
+    class PhaseAge(val active: Age, val alsoAccepted: Iterable[Age] = None) extends PhaseAges
 
     object Upcoming   extends PhaseAge(active = Old, alsoAccepted = Some(New))
     object InProgress extends PhaseAge(active = New, alsoAccepted = Some(Old))

--- a/core/src/main/scala/com/gu/play/secretrotation/Phase.scala
+++ b/core/src/main/scala/com/gu/play/secretrotation/Phase.scala
@@ -10,7 +10,7 @@ import scala.collection.SortedMap
 trait Phase[T] {
   val active: T
 
-  val alsoAccepted: Traversable[T]
+  val alsoAccepted: Iterable[T]
 
   final def onlyAcceptsActive = alsoAccepted.isEmpty
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,6 +1,6 @@
 sonatypeProfileName := "com.gu"
 
-publishTo in ThisBuild := sonatypePublishTo.value
+publishTo in ThisBuild := sonatypePublishToBundle.value
 
 scmInfo in ThisBuild := Some(ScmInfo(
   url("https://github.com/guardian/play-secret-rotation"),


### PR DESCRIPTION
This project compiles with Scala 2.12 by default, but now additionally can cross-compile to Scala 2.13 almost everywhere (not Play 2.6 because that never supported Scala 2.13).

* Use `Iterable` in preference to the deprecated `Traversable` trait
  https://www.scala-lang.org/blog/2017/02/28/collections-rework.html#traversable-and-iterable
  https://www.scala-lang.org/blog/2018/06/13/scala-213-collections.html#iterable-is-the-top-collection-type
* `scaffeine` & `scalatest` both updated to cross-compiled versions

Additional sbt changes:

* Use the latest version of sbt, which is faster at downloading dependencies!
  https://www.lightbend.com/blog/sbt-1.3.0-release
* Use the latest version of `sbt-sonatype`, which has improved upload times into sonatype by using bundling!
  https://github.com/xerial/sbt-sonatype/issues/89