### PR TITLE
Upgrade sbt and other dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,19 +1,19 @@
 import ReleaseTransformations._
 
 lazy val baseSettings = Seq(
-  scalaVersion := "2.12.14",
+  scalaVersion := "2.12.15",
   organization := "com.gu.play-secret-rotation",
   licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
   scalacOptions ++= Seq("-deprecation", "-Xlint", "-unchecked")
 )
 
-lazy val crossCompileScala213 = crossScalaVersions := Seq(scalaVersion.value, "2.13.6")
+lazy val crossCompileScala213 = crossScalaVersions := Seq(scalaVersion.value, "2.13.7")
 
 lazy val core =
   project.settings(crossCompileScala213, baseSettings).settings(
     libraryDependencies ++= Seq(
       "com.github.blemale" %% "scaffeine" % "3.1.0",
-      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.3",
+      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
       "org.threeten" % "threeten-extra" % "1.7.0",
       "org.scalatest" %% "scalatest" % "3.2.9" % Test
     ),
@@ -23,8 +23,8 @@ lazy val `aws-parameterstore-secret-supplier-base` =
   project.in(file("aws-parameterstore/secret-supplier")).settings(crossCompileScala213, baseSettings).dependsOn(core)
 
 val awsSdkForVersion = Map(
-  1 -> "com.amazonaws" % "aws-java-sdk-ssm" % "1.12.62",
-  2 -> "software.amazon.awssdk" % "ssm" % "2.17.34"
+  1 -> "com.amazonaws" % "aws-java-sdk-ssm" % "1.12.129",
+  2 -> "software.amazon.awssdk" % "ssm" % "2.17.100"
 )
 
 def awsParameterStoreWithSdkVersion(version: Int)=
@@ -40,7 +40,7 @@ lazy val `aws-parameterstore-lambda` = project.in(file("aws-parameterstore/lambd
   .settings(crossCompileScala213, baseSettings).dependsOn(`secret-generator`).settings(
   libraryDependencies ++= Seq(
     "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
-    "com.amazonaws" % "aws-lambda-java-events" % "3.10.0",
+    "com.amazonaws" % "aws-lambda-java-events" % "3.11.0",
     awsSdkForVersion(1)
   )
 )
@@ -50,7 +50,7 @@ lazy val `secret-generator` = project.settings(crossCompileScala213, baseSetting
 val exactPlayVersions = Map(
   "26" -> "2.6.25",
   "27" -> "2.7.9",
-  "28" -> "2.8.8"
+  "28" -> "2.8.11"
 )
 
 def playVersion(majorMinorVersion: String)= {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.5.6


### PR DESCRIPTION
`sbt dependencyTree` confirms there is no Log4J in this project's dependencies.
