### PR TITLE
Fix missing `RotatingSecretComponents`

### DIFF
--- a/play/play-v28/RotatingSecretComponents.scala
+++ b/play/play-v28/RotatingSecretComponents.scala
@@ -1,1 +1,1 @@
-../play-v26/RotatingSecretComponents.scala
+../play-v27/RotatingSecretComponents.scala

--- a/play/play-v29/RotatingSecretComponents.scala
+++ b/play/play-v29/RotatingSecretComponents.scala
@@ -1,1 +1,1 @@
-../play-v26/RotatingSecretComponents.scala
+../play-v27/RotatingSecretComponents.scala

--- a/play/play-v30/RotatingSecretComponents.scala
+++ b/play/play-v30/RotatingSecretComponents.scala
@@ -1,1 +1,1 @@
-../play-v26/RotatingSecretComponents.scala
+../play-v27/RotatingSecretComponents.scala


### PR DESCRIPTION
Not long after I was warned that symbolic links are dangerous, I broke some symbolic links! In https://github.com/guardian/play-secret-rotation/pull/411 I dropped support for Play v2.6, but didn't correctly update all the symbolic links in this project to point to the Play 2.7 version of the code - so all the links were broken, and the result was that the published artifacts (version 0.39) did not have `RotatingSecretComponents` in them.
