### PR TITLE
Adopt GHA Scala Library Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    permissions:
+      contents: write
+    secrets:
+      AUTOMATED_MAVEN_RELEASE_PGP_SECRET: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
+      AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
-import ReleaseTransformations._
+import ReleaseTransformations.*
+import sbtversionpolicy.withsbtrelease.ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease
 
 lazy val baseSettings = Seq(
   scalaVersion := "2.13.11",
@@ -86,9 +87,8 @@ lazy val `play-secret-rotation-root` = (project in file("."))
     `aws-parameterstore-lambda`
   )
   .settings(baseSettings).settings(
-  publishArtifact := false,
-  publish := {},
-  publishLocal := {},
+  publish / skip := true,
+  releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value,
   releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,
@@ -98,11 +98,7 @@ lazy val `play-secret-rotation-root` = (project in file("."))
     setReleaseVersion,
     commitReleaseVersion,
     tagRelease,
-    // For non cross-build projects, use releaseStepCommand("publishSigned")
-    releaseStepCommandAndRemaining("+publishSigned"),
-    releaseStepCommand("sonatypeBundleRelease"),
     setNextVersion,
-    commitNextVersion,
-    pushChanges
+    commitNextVersion
   )
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.1.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
 

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,7 +1,3 @@
-sonatypeProfileName := "com.gu"
-
-ThisBuild / publishTo := sonatypePublishToBundle.value
-
 ThisBuild / scmInfo := Some(ScmInfo(
   url("https://github.com/guardian/play-secret-rotation"),
   "scm:git:git@github.com:guardian/play-secret-rotation.git"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.41-SNAPSHOT"
+ThisBuild / version := "1.0.0-SNAPSHOT"


### PR DESCRIPTION
This is the second library (after [`etag-caching`](https://github.com/guardian/etag-caching)), to adopt [`guardian/gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow) . This is a new automated library release process, which means that a new library release can be published to Maven Central with the click of a button:

<img width="1644" alt="image" src="https://github.com/guardian/play-secret-rotation/assets/52038/dcb804f5-ff9f-46a6-a9cb-2627c073686f">

This replaces the old release process which had developers manually running `sbt release` on their own laptops - each developer had to obtain their own PGP key and Sonatype credentials, which was an elaborate setup process. Now, there is one single set of credentials, available through GitHub Organisation Secrets, like we already do with NPM.

### Required changes

The changes required to adopt the automated workflow:

* No need to set `sonatypeProfileName` or `ThisBuild / publishTo`, that's now done by the workflow.
* Remove the sign, publish, release & push steps of sbt-release's `releaseProcess` configuration, because the workflow does those now, and the workflow only wants `sbt release` to create the versioning commits, and tag them appropriately. The workflow does the rest itself.
* Remove `sbt-pgp` plugin because it's no longer used - the workflow does the signing using `gpg` directly.
* GitHub administration: Grant this repo ([`play-secret-rotation`](https://github.com/guardian/play-secret-rotation)) access to these two GitHub Organisation Secrets (probably requires Organisation Owner privileges):
  *  [`AUTOMATED_MAVEN_RELEASE_PGP_SECRET`](https://github.com/organizations/guardian/settings/secrets/actions/AUTOMATED_MAVEN_RELEASE_PGP_SECRET) & 
  * [`AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD`](https://github.com/organizations/guardian/settings/secrets/actions/AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD):

Additionally, we add **automatic version numbering** based on compatibility assessment performed by `sbt-version-policy`:

* Add the `sbt-version-policy` plugin, to allow it to do the compatibility assessment. This also sets the `versionScheme` for this library to `early-semver`, which is the recommended versioning for Scala libraries, and `sbt-version-policy` and correct sbt-eviction-issue-detection pretty much depend on the `versionScheme` being `early-semver`. Thus we also need to switch to using a new semver version number for our library version!
* Add the `releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value` sbt setting, which will intelligently set the release version based on `sbt-version-policy`'s compatibility assessment, thanks to https://github.com/scalacenter/sbt-version-policy/pull/187 .
* Use `publish / skip := true`, rather than other hacks like `publish := {}` or `publishArtifact := false`, to tell sbt not to publish modules that we don't want published (typically, the 'root' module) - this is important because `sbt-version-policy` won't understand those hacks, but _will_ understand `publish / skip := true` means that it doesn't need to assess compatibility there.
