### PR TITLE
Fix release problem with `secret-generator`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,7 @@ lazy val `play-secret-rotation-root` = (project in file("."))
     `aws-parameterstore-secret-supplier-base`,
     `aws-parameterstore-sdk-v1`,
     `aws-parameterstore-sdk-v2`,
+    `secret-generator`,
     `aws-parameterstore-lambda`
   )
   .settings(baseSettings).settings(


### PR DESCRIPTION
Releasing v1.0.0 with https://github.com/guardian/gha-scala-library-release-workflow worked fine, but trying to release v1.0.1 failed, due to the unusual configuration of the `secret-generator` subproject:

https://github.com/guardian/play-secret-rotation/actions/runs/7113763098/job/19366398526#step:4:153

```
[error] (aws-parameterstore-lambda / mimaPreviousClassfiles) sbt.librarymanagement.ResolveException: Error downloading com.gu.play-secret-rotation:secret-generator_2.13:1.0.0
[error]   Not found
[error]   Not found
[error]   not found: /home/runner/.ivy2/localcom.gu.play-secret-rotation/secret-generator_2.13/1.0.0/ivys/ivy.xml
[error]   not found: https://repo1.maven.org/maven2/com/gu/play-secret-rotation/secret-generator_2.13/1.0.0/secret-generator_2.13-1.0.0.pom
[error] (aws-parameterstore-lambda / versionPolicyFindDependencyIssues) sbt.librarymanagement.ResolveException: Error downloading com.gu.play-secret-rotation:secret-generator_2.13:1.0.0
```

Nothing actually needs `secret-generator` as a library artifact - `aws-parameterstore-lambda` uses `sbt-assembly` to incorporate all it's dependencies into a single jar, so even though it uses secret-generator, it doesn't need it as a separate artifact. However, the new compatibility-based version-numbering functionality introduced in https://github.com/scalacenter/sbt-version-policy/pull/187 wants to compare with previous versions of project dependencies, and it doesn't understand the dependency isn't published...

It's easier to publish the artifact, so I'm doing that here!
