### PR TITLE
Fix compatibility-version-numbering - skip über jar

### DIFF
--- a/aws-parameterstore/lambda/build.sbt
+++ b/aws-parameterstore/lambda/build.sbt
@@ -1,6 +1,9 @@
 // replace the conventional main artifact with an uber-jar
 addArtifact(Compile / packageBin / artifact, assembly)
 
+// see https://github.com/scalacenter/sbt-version-policy/issues/190
+versionPolicyAssessCompatibility / skip := true
+
 assembly / assemblyMergeStrategy := {
   {
     case PathList("META-INF", _ @ _*) => MergeStrategy.discard


### PR DESCRIPTION
Further to #416, `sbt-version-policy` kept deciding that every release (eg [`v6.0.0`](https://github.com/guardian/play-secret-rotation/releases/tag/v6.0.0)) needed a 'MAJOR' version bump, even when there were no changes between releases: https://github.com/guardian/play-secret-rotation/compare/v5.0.0...v6.0.0

This is due to our submodule `aws-parameterstore-lambda` being released as an über jar (with `sbt-assembly`) and the issue https://github.com/scalacenter/sbt-version-policy/issues/190 .

I think setting `versionPolicyAssessCompatibility / skip := true` on the submodule may well be enough to fix the issue, though only if `fromAggregatedAssessedCompatibilityWithLatestRelease()` respects it - lets see if it will!

