### PR TITLE
Fix `CSRFTokenSigner` - it needs to cope with rotated secrets too

### DIFF
--- a/core/src/main/scala/com/gu/play/secretrotation/SnapshotProvider.scala
+++ b/core/src/main/scala/com/gu/play/secretrotation/SnapshotProvider.scala
@@ -21,6 +21,15 @@ trait SecretsSnapshot {
     *                      algorithm (eg a weak algorithm, even 'none' : https://tools.ietf.org/html/rfc7519#section-6.1 )
     */
   def decode[T](decodingFunc: String => T, conclusiveDecode: T => Boolean): Option[T]
+
+  /**
+   * This convenience function lets you attempt to decode a value using all applicable secrets, assuming that a
+   * successful decode will lead to a populated Option.
+   *
+   * @param decodingFunc a function that attempts to decode a value using the provided secret - the function should
+   *                     return Some(value) if the decoding was successful, or None if it was not
+   */
+  def decodeOpt[T](decodingFunc: String => Option[T]): Option[T] = decode[Option[T]](decodingFunc, _.nonEmpty).flatten
 }
 
 trait SnapshotProvider {
@@ -43,6 +52,3 @@ trait CachingSnapshotProvider extends SnapshotProvider {
 
   def loadState(): SnapshotProvider
 }
-
-
-


### PR DESCRIPTION
This fixes https://github.com/guardian/play-secret-rotation/issues/445 - although `play-secret-rotation` has always overridden Play's `RequestFactory` to handle rotating the [Play Application Secret](https://www.playframework.com/documentation/3.0.x/ApplicationSecret), we forgot to also override the `CSRFTokenSigner` to teach _it_ about rotating secrets - this PR fixes that.

Essential to coping with rotating secret keys is the ability to tolerate tokens signed with _old_ secret keys for a transition period (for us the overlap period is 2 hours). So our `RotatingKeyCSRFTokenSigner` needs to always _sign_ with the 'current' secret, but when verifying tokens, needs to **try** verifying the token against _all_ applicable secret keys, to see if any of them validate it.

See also:

* https://github.com/guardian/ophan/issues/5970
* https://github.com/guardian/ophan/pull/5985
