### PR TITLE
Reduce logging warning about accepting old secrets

### DIFF
--- a/core/src/main/scala/com/gu/play/secretrotation/DualSecretTransition.scala
+++ b/core/src/main/scala/com/gu/play/secretrotation/DualSecretTransition.scala
@@ -1,8 +1,7 @@
 package com.gu.play.secretrotation
 
 import java.time.Clock.systemUTC
-import java.time.{Clock, Duration}
-
+import java.time.{Clock, Duration, Instant}
 import com.gu.play.secretrotation.DualSecretTransition.Phase.{Completed, InProgress, Upcoming}
 import com.gu.play.secretrotation.DualSecretTransition.Secret.{Age, New, Old}
 import org.threeten.extra.Interval
@@ -59,7 +58,7 @@ object DualSecretTransition {
 
     val overlapDuration = overlapInterval.toDuration
     val permittedSnapshotStaleness = overlapDuration.dividedBy(10)
-    val warningThreshold = overlapInterval.getStart.plus(overlapDuration.dividedBy(3).multipliedBy(2))
+    val warningThreshold: Instant = overlapInterval.getEnd.minus(overlapDuration.dividedBy(5))
 
     def snapshot(): SecretsSnapshot = {
       val snapshotTime = clock.instant()


### PR DESCRIPTION
Following on from https://github.com/guardian/play-secret-rotation/pull/2, looking at Ophan's logs for the "Accepted decode with non-active key" warning message, we can see that in the recent 24 hour period, there are still [over 100 logged warnings](https://logs.gutools.co.uk/s/ophan/goto/19c2ea70-f1f5-11ee-be1c-d5e1a37b2c42):



![image](https://github.com/guardian/play-secret-rotation/assets/52038/abbdaef9-ab3f-4558-a763-b024f2f30ec5)


PR #2 was an update that meant encountering an old key would only be logged as a warning if we were in the final third (1/3) of the overlap period for the transition - usually the overlap period is 2 hours, so we'd only log a warning if we received something signed with an old secret in the last 40 minutes of the overlap period.

To reduce the level of logged messages further, we now restrict ourselves to logging a warning in the final 1/5 of the overlap period - 24 minutes. Based on Ophan logging, this won't get rid of warnings altogether, but will reduce them quite sharply.
