### PR TITLE
Fix use of `withFallback` introduced when dropping Play 2.7

### DIFF
--- a/play/play-v28/RotatingSecretComponents.scala
+++ b/play/play-v28/RotatingSecretComponents.scala
@@ -20,7 +20,7 @@ trait RotatingSecretComponents extends BuiltInComponentsFromContext {
   override def configuration: Configuration = {
     val nonRotatingSecretOnlyUsedToSatisfyConfigChecks = secretStateSupplier.snapshot().secrets.active
 
-    super.configuration.withFallback(Configuration("play.http.secret.key" -> nonRotatingSecretOnlyUsedToSatisfyConfigChecks))
+    Configuration("play.http.secret.key" -> nonRotatingSecretOnlyUsedToSatisfyConfigChecks).withFallback(super.configuration)
   }
 
   override lazy val requestFactory: RequestFactory =


### PR DESCRIPTION
This fixes https://github.com/guardian/play-secret-rotation/issues/449, the problem with server startup that was introduced by dropping Play 2.7 support in PR https://github.com/guardian/play-secret-rotation/pull/446 and released with play-secret-rotation [v8.1.0](https://github.com/guardian/play-secret-rotation/releases/tag/v8.1.0).

Dropping Play 2.7 support meant that we could use the `Configuration.withFallback()` method introduced with Play 2.8 and https://github.com/playframework/playframework/pull/9674, rather than the deprecated `++` method. However (as the documentation does say), the `++` and `withFallback()` methods override in _opposite_ directions - `withFallback()` means that the first `Configuration` is tried _first_, and the second config is tried _second_ - which is opposite to how `++` works.

I missed this, and so, in PR https://github.com/guardian/play-secret-rotation/pull/446, failed to reverse the order of the arguments. This meant that when `play-secret-rotation` was actually in a Play server running in Production mode, the code would attempt to evaluate the `play.http.secret.key` key in `super.configuration` (and blow up with an integrity test error), rather than get the trash value back that `Configuration("play.http.secret.key" -> nonRotatingSecretOnlyUsedToSatisfyConfigChecks)` supplied - only To Satisfy Config Checks.

Reversing the order of the arguments makes the hack work as intended, and the server can start up again 👍 ✨ 

It would be lovely to avoid such hackage, but that will require a resolution for https://github.com/playframework/playframework/issues/12520!

## Testing

This has been tried out with https://github.com/guardian/ophan/pull/6005, which demonstrated that the change fixes the problem.