### PR TITLE
Temporarily disable compatibility testing as last release failed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,7 @@ lazy val `play-secret-rotation-root` = (project in file("."))
   )
   .settings(baseSettings).settings(
   publish / skip := true,
-  releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+//  releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value,
   releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,


### PR DESCRIPTION
See here more info: https://github.com/guardian/gha-scala-library-release-workflow/issues/33