### PR TITLE
Include scalatest test results on stdout

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ lazy val baseSettings = Seq(
   licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-release:11"),
   Test / testOptions +=
-    Tests.Argument(TestFrameworks.ScalaTest,"-u", s"test-results/scala-${scalaVersion.value}")
+    Tests.Argument(TestFrameworks.ScalaTest,"-u", s"test-results/scala-${scalaVersion.value}", "-o")
 )
 
 val jacksonOverride = "com.fasterxml.jackson.core" % "jackson-core" % "2.17.2"


### PR DESCRIPTION
## What does this change?

By default, using scalatest’s -u flag (which outputs test results to a junit xml file) stops the results from appearing on stdout: there’s still a final summary, but not the test-by-test output. This can make it a bit difficult to tell at a glance which tests have failed, so in this PR I’ve added the -o flag to restore the stdout output.