### PR TITLE
Run Snyk On `main` Branch Only

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -2,6 +2,8 @@ name: Snyk
 
 on: 
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This is the configuration we use in other projects.

Suggested in https://github.com/guardian/play-secret-rotation/pull/494#pullrequestreview-2292607387

Examples from other projects:

- https://github.com/guardian/guardian-configuration/blob/ba5da1b4267c6474ff4b540bbd2db6bc52922599/.github/workflows/snyk.yml
- https://github.com/guardian/simple-configuration/blob/94bd979b5c35b927af6be9c480afd72fd262bf8a/.github/workflows/snyk.yml
