### PR TITLE
Bump aws-sdk to fix high vuln in netty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val `aws-parameterstore-secret-supplier-base` =
 
 val awsSdkForVersion = Map(
   1 -> "com.amazonaws" % "aws-java-sdk-ssm" % "1.12.777",
-  2 -> "software.amazon.awssdk" % "ssm" % "2.29.9"
+  2 -> "software.amazon.awssdk" % "ssm" % "2.29.17"
 )
 
 def awsParameterStoreWithSdkVersion(version: Int)=


### PR DESCRIPTION
## What does this change?

Bumps aws-sdk to fix a high vulnerability in Netty. This should resolve https://github.com/guardian/play-secret-rotation/security/dependabot/1.

## How to test

This is a patch release, and should not require testing.