### PR TITLE
Install Java and sbt in dependency-graph workflow

### DIFF
--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -1,19 +1,28 @@
-name: Update Dependency Graph for SBT
+name: Update Dependency Graph for sbt
 on:
   push:
     branches:
       - main
-  workflow_dispatch: 
+  workflow_dispatch:
 jobs:
   dependency-graph:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
         id: checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Install Java
+        id: java
+        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.2.0
+        with:
+          distribution: corretto
+          java-version: 17
+      - name: Install sbt
+        id: sbt
+        uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
       - name: Submit dependencies
         id: submit
-        uses: scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1
+        uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0
       - name: Log snapshot for user validation
         id: validate
         run: cat ${{ steps.submit.outputs.snapshot-json-path }} | jq


### PR DESCRIPTION
## What does this change?

The sbt-dependency-graph workflow has started failing, because it uses ubuntu-latest but doesn’t install Java or sbt: since github have updated ubuntu-latest to point to ubuntu-24.04, it has less software pre-installed by default.

The updates come from copying the version in
https://github.com/guardian/content-api-transformer-lambda/pull/95, which was raised by the bot recently and has been updated to install the necessary dependencies.

## How to test

We could alter the triggers for the workflow to let it run on this branch in order to test it, but since it's working correctly on content-api-transformer-lambda already, I'm tempted to just merge and see.