### PR TITLE
Update release workflow to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release:
-    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@v1
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@v2
     permissions: { contents: write, pull-requests: write }
     secrets:
       SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,4 @@ addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
-
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")


### PR DESCRIPTION
See:

* https://github.com/guardian/gha-scala-library-release-workflow/releases/tag/v2.0.0
* https://github.com/guardian/gha-scala-library-release-workflow/pull/62