### PR TITLE
software.amazon.awssdk:ssm -> 2.32.27

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val `aws-parameterstore-secret-supplier-base` =
 
 val awsSdkForVersion = Map(
   1 -> "com.amazonaws" % "aws-java-sdk-ssm" % "1.12.788",
-  2 -> "software.amazon.awssdk" % "ssm" % "2.32.12"
+  2 -> "software.amazon.awssdk" % "ssm" % "2.32.27"
 )
 
 def awsParameterStoreWithSdkVersion(version: Int)=


### PR DESCRIPTION
## What does this change?

Bumps `software.amazon.awssdk:ssm` -> `2.32.27` to bring in `netty-codec-http2:4.1.124.Final`, addressing https://github.com/advisories/GHSA-prj3-ccx8-p6x4

## How to test

The library should compile as expected.
