### PR TITLE
Try overriding the vulnerable version of lz4-java to a fixed version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ lazy val baseSettings = Seq(
 )
 
 val jacksonOverride = "com.fasterxml.jackson.core" % "jackson-core" % "2.20.1"
+val lz4JavaOverride = "org.lz4" % "lz4-java" % "1.8.1"
 
 lazy val core =
   project.settings(baseSettings).settings(
@@ -64,6 +65,7 @@ def playVersion(majorMinorVersion: String)= {
     .settings(libraryDependencies ++= Seq(
       exactPlayVersions(majorMinorVersion),
       jacksonOverride,
+      lz4JavaOverride,
     ))
 }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add an override to lz4-java to force the fixed version - https://github.com/advisories/GHSA-vqf4-7m7x-wgfc

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
