### PR TITLE
Drop Play v2.9 support

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,3 +1,0 @@
-updates.ignore = [
-  { groupId = "com.typesafe.play", artifactId = "play" }
-]

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 play-secret-rotation
 =========
 
-_Rotating your [Application Secret](https://www.playframework.com/documentation/2.9.x/ApplicationSecret)
+_Rotating your [Application Secret](https://www.playframework.com/documentation/3.0.x/ApplicationSecret)
 on an active cluster of Play app servers - without downtime_
 
 [![Release](https://github.com/guardian/play-secret-rotation/actions/workflows/release.yml/badge.svg)](https://github.com/guardian/play-secret-rotation/actions/workflows/release.yml)
 
 [![play-secret-rotation artifacts](https://index.scala-lang.org/guardian/play-secret-rotation/play-v30/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/play-secret-rotation/play-v30/)
-
-[![play-secret-rotation artifacts](https://index.scala-lang.org/guardian/play-secret-rotation/play-v29/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/play-secret-rotation/play-v29/)
 
 #### How to use this Play add-on
 

--- a/aws-parameterstore/README.md
+++ b/aws-parameterstore/README.md
@@ -38,7 +38,7 @@ You'll need to add two library dependencies for `com.gu.play-secret-rotation` - 
 to your Play version, and another specific to your AWS SDK version:
 
 * **Play** ... 
-[![play-secret-rotation artifacts](https://index.scala-lang.org/guardian/play-secret-rotation/play-v30/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/play-secret-rotation/play-v30/) [![play-secret-rotation artifacts](https://index.scala-lang.org/guardian/play-secret-rotation/play-v29/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/play-secret-rotation/play-v29/) [![play-secret-rotation artifacts](https://index.scala-lang.org/guardian/play-secret-rotation/play-v28/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/play-secret-rotation/play-v28/)
+[![play-secret-rotation artifacts](https://index.scala-lang.org/guardian/play-secret-rotation/play-v30/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/play-secret-rotation/play-v30/)
 * **AWS SDK** ([v1 or v2](https://docs.aws.amazon.com/sdk-for-java/latest/migration-guide/what-is-java-migration.html)) ... [![play-secret-rotation artifacts](https://index.scala-lang.org/guardian/play-secret-rotation/aws-parameterstore-sdk-v2/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/play-secret-rotation/aws-parameterstore-sdk-v2/)
   [![play-secret-rotation artifacts](https://index.scala-lang.org/guardian/play-secret-rotation/aws-parameterstore-sdk-v1/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/play-secret-rotation/aws-parameterstore-sdk-v1/)
 
@@ -46,7 +46,7 @@ So, for example:
 
 ```scala
 libraryDependencies ++= Seq(
-  "com.gu.play-secret-rotation" %% "play-v28" % "0.x",
+  "com.gu.play-secret-rotation" %% "play-v30" % "0.x",
   "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "0.x",
 )
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val baseSettings = Seq(
   scalaVersion := "2.13.18",
   crossScalaVersions := Seq(scalaVersion.value, "3.3.7"),
   organization := "com.gu.play-secret-rotation",
-  licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
+  licenses := Seq(License.Apache2),
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-release:11"),
   Test / testOptions +=
     Tests.Argument(TestFrameworks.ScalaTest,"-u", s"test-results/scala-${scalaVersion.value}", "-o")
@@ -53,7 +53,6 @@ lazy val `aws-parameterstore-lambda` = project.in(file("aws-parameterstore/lambd
 lazy val `secret-generator` = project.settings(baseSettings)
 
 val exactPlayVersions = Map(
-  "29" -> "com.typesafe.play" %% "play" % "2.9.5",
   "30" -> "org.playframework" %% "play" % "3.0.10"
 )
 
@@ -67,14 +66,12 @@ def playVersion(majorMinorVersion: String)= {
     ))
 }
 
-lazy val `play-v29` = playVersion("29")
 lazy val `play-v30` = playVersion("30")
 
 
 lazy val `play-secret-rotation-root` = (project in file("."))
   .aggregate(
     core,
-    `play-v29`,
     `play-v30`,
     `aws-parameterstore-secret-supplier-base`,
     `aws-parameterstore-sdk-v1`,


### PR DESCRIPTION
We should be using Play v3 everywhere at the Guardian!

Also, although `play-secret-rotation` release [v16.0.0](https://github.com/guardian/play-secret-rotation/releases/tag/v16.0.0) fixed GHSA-vqf4-7m7x-wgfc for `play-secret-rotation`'s Play v3 artifact, it did not fix the Play *v2.9* artifact (Scala Steward has not been doing v2.9 updates since 607802e387b082de605a27b2097d1e1efd92d3a5). Dropping Play v2.9 means we don't need to fix that!

See also:

* https://github.com/guardian/maintaining-scala-projects/issues/4
* https://github.com/guardian/play-googleauth/pull/362

