### PR TITLE
Bump aws ssm

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val `aws-parameterstore-secret-supplier-base` =
   project.in(file("aws-parameterstore/secret-supplier")).settings(baseSettings).dependsOn(core)
 
 val awsSdkForVersion = Map(
-  2 -> "software.amazon.awssdk" % "ssm" % "2.42.41"
+  2 -> "software.amazon.awssdk" % "ssm" % "2.46.8"
 )
 
 def awsParameterStoreWithSdkVersion(version: Int)=


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Bumps AWS ssm

## Why?
In order to bump transitive dependency netty-codec. It was updated in https://github.com/aws/aws-sdk-java-v2/pull/7016.


